### PR TITLE
Fix links to parts for socket headers and pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ JP2, and JP3, and reclosing the jumpers JP4, JP5, and JP6.
 
 Due to the space for the USB cable in the back, there's not enough room in the
 case for a standard socket header, but there are low-profile pin headers that
-do fit. [These square-pin socket headers](short-sockets) and [pins](short-pins)
+do fit. [These square-pin socket headers][short-sockets] and [pins][short-pins]
 with 0.180" (4.57mm) insulation height have been verified to fit in the KB500,
 and will probably fit the KB600 as well. Round "Swiss-style" headers may also
 work, but make sure to get the appropriate matching pins for whatever socket


### PR DESCRIPTION
Slightly incorrect markdown syntax was preventing these links from rendering 
correctly.